### PR TITLE
Workaround Linkedin missing icon

### DIFF
--- a/blog/Apr_21_2021.html
+++ b/blog/Apr_21_2021.html
@@ -156,8 +156,8 @@
                     <a href="https://www.linkedin.com/in/maishiroma" target="_blank">
                         <img class="moreDetails-icons" src="../assets/images/icons/LinkedinIcon.png"
                             alt="Linkedin icon">
+                        <h3>My LinkedIn Profile</h3>
                     </a>
-                    <h3>My LinkedIn Profile</h3>
                 </div>
             </div><!-- container -->
         </div><!-- contact-area -->

--- a/blog/Dec_5_2018.html
+++ b/blog/Dec_5_2018.html
@@ -163,8 +163,8 @@
                     <a href="https://www.linkedin.com/in/maishiroma" target="_blank">
                         <img class="moreDetails-icons" src="../assets/images/icons/LinkedinIcon.png"
                             alt="Linkedin icon">
+                        <h3>My LinkedIn Profile</h3>
                     </a>
-                    <h3>My LinkedIn Profile</h3>
                 </div>
             </div><!-- container -->
         </div><!-- contact-area -->

--- a/blog/Sept_17_2018.html
+++ b/blog/Sept_17_2018.html
@@ -208,8 +208,8 @@
                     <a href="https://www.linkedin.com/in/maishiroma" target="_blank">
                         <img class="moreDetails-icons" src="../assets/images/icons/LinkedinIcon.png"
                             alt="Linkedin icon">
+                        <h3>My LinkedIn Profile</h3>
                     </a>
-                    <h3>My LinkedIn Profile</h3>
                 </div>
             </div><!-- container -->
         </div><!-- contact-area -->

--- a/blog/Sept_18_2018.html
+++ b/blog/Sept_18_2018.html
@@ -184,8 +184,8 @@
                     <a href="https://www.linkedin.com/in/maishiroma" target="_blank">
                         <img class="moreDetails-icons" src="../assets/images/icons/LinkedinIcon.png"
                             alt="Linkedin icon">
+                        <h3>My LinkedIn Profile</h3>
                     </a>
-                    <h3>My LinkedIn Profile</h3>
                 </div>
             </div><!-- container -->
         </div><!-- contact-area -->

--- a/blog/index.html
+++ b/blog/index.html
@@ -155,8 +155,8 @@
                     <a href="https://www.linkedin.com/in/maishiroma" target="_blank">
                         <img class="moreDetails-icons" src="../assets/images/icons/LinkedinIcon.png"
                             alt="Linkedin icon">
+                        <h3>My LinkedIn Profile</h3>
                     </a>
-                    <h3>My LinkedIn Profile</h3>
                 </div>
             </div><!-- container -->
         </div><!-- contact-area -->

--- a/index.html
+++ b/index.html
@@ -708,8 +708,8 @@
                 <div class="moreDetails noselect">
                     <a href="https://www.linkedin.com/in/maishiroma" target="_blank">
                         <img class="moreDetails-icons" src="assets/images/icons/LinkedinIcon.png" alt="Linkedin icon">
+                        <h3>My LinkedIn Profile</h3>
                     </a>
-                    <h3>My LinkedIn Profile</h3>
                 </div>
             </div><!-- container -->
         </div><!-- contact-area -->


### PR DESCRIPTION
Fix:
- Made the header in the contact section a link so if the image is still missing (due to cache) the link will still be navigatable