### PR TITLE
Fixed Resume Dropbox Link to be a direct download instead

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -144,7 +144,7 @@ params:
     button:
       enable: true
       name: "Resume"
-      url: "https://www.dropbox.com/scl/fi/kbfo5u58473ewdj7jkv6k/MS_General_Resume.pdf?rlkey=8xkpcolur1zvxluxgzcfaq218&dl=0"
+      url: https://www.dropbox.com/scl/fi/kbfo5u58473ewdj7jkv6k/MS_General_Resume.pdf?rlkey=8xkpcolur1zvxluxgzcfaq218&dl=1
       download: false
       newPage: true
     socialLinks:


### PR DESCRIPTION
I heard from a bud that apparently the dropbox link doesn't really give a proper link to the resume anymore. I fixed it.